### PR TITLE
feat: add support for @test

### DIFF
--- a/lua/neotest-phpunit/init.lua
+++ b/lua/neotest-phpunit/init.lua
@@ -95,6 +95,15 @@ function adapter.discover_positions(path)
         name: (name) @test.name
         (#match? @test.name "test"))
         @test.definition
+  
+    ((class_declaration
+      body: (declaration_list
+          (comment) @comment (#match? @comment "@test")
+            (method_declaration
+              (name) @test.name)
+        )
+    ))
+    @test.definition
 
     (namespace_definition
         name: (namespace_name) @namespace.name)


### PR DESCRIPTION
This query should support for:

```php
/** @test */
```

```php
/**
@test
*/
```

## From Treesitter Playground

<img width="714" alt="Screen Shot 2022-06-19 at 18 34 38@2x" src="https://user-images.githubusercontent.com/9512444/174493470-6c31a0be-0448-49d5-8b4d-6356643f7a76.png">
