### PR TITLE
fix: add anchor to ts query

### DIFF
--- a/lua/neotest-phpunit/init.lua
+++ b/lua/neotest-phpunit/init.lua
@@ -98,9 +98,10 @@ function adapter.discover_positions(path)
   
     ((class_declaration
       body: (declaration_list
-          (comment) @comment (#match? @comment "@test")
+          (comment) @comment (#match? @comment "@test") .
             (method_declaration
-              (name) @test.name)
+              (name) @test.name
+            )
         )
     ))
     @test.definition


### PR DESCRIPTION
Not having the anchor previously meant that we were picking up any method name in the test file, as long as `/** @test */` block existed.

## Before

<img width="711" alt="Screen Shot 2022-06-19 at 23 21 39@2x" src="https://user-images.githubusercontent.com/9512444/174502477-36194884-1a75-4558-8de5-b8e21e2f9d1a.png">

## After

![Screen Shot 2022-06-19 at 23 21 52@2x](https://user-images.githubusercontent.com/9512444/174502491-72c2e899-5429-4b70-a7d1-158ccb53e8c9.png)
